### PR TITLE
Fix for #13 model download error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "cp env.sample .env && vite",
+    "dev": "[ -f .env ] || cp env.sample .env  && vite",
     "build": "[ -f .env ] || cp env.sample .env && vite build && cp _headers dist/_headers",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "cp env.sample .env && vite",
     "build": "[ -f .env ] || cp env.sample .env && vite build && cp _headers dist/_headers",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",


### PR DESCRIPTION
Without a .env file the software doesn't know where to download the model files and tries to get them from localhost.